### PR TITLE
fix: proper named export

### DIFF
--- a/app/helpers/ref-to.js
+++ b/app/helpers/ref-to.js
@@ -1,1 +1,1 @@
-export { default, refTo } from 'ember-ref-bucket/helpers/ref-to';
+export { default, default as refTo } from 'ember-ref-bucket/helpers/ref-to';


### PR DESCRIPTION
As you did in https://github.com/jmurphyau/ember-truth-helpers/pull/110/, this fixes an Embroider export warning thrown by usage in Ember Bootstrap:

```
WARNING in ./helpers/ref-to.js 1:0-81
    "export 'refTo' was not found in '../node_modules/ember-ref-bucket/helpers/ref-to'
     @ ./assets/<app-name>.js
```