### PR TITLE
drop support for node 10, 12 and all others which reached end of life

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '12.x'
+  NODE_VERSION: '14.x'
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Compatibility
 
 * Ember.js v3.20 or above
 * Ember CLI v3.20 or above
-* Node.js v10 or above
+* Node.js v14 or above
 
 
 Installation

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This drops support for all node versions, which reached end of life already. It will enable us depending on packages, which dropped support already. It is required for supporting ember-modifier v4. It is a breaking change.