### PR TITLE
Clean lastGlobalRef on destruction of {{create-ref}} modifier

### DIFF
--- a/addon/instance-initializers/global-ref-cleanup.js
+++ b/addon/instance-initializers/global-ref-cleanup.js
@@ -1,0 +1,12 @@
+import { registerDestructor } from '@ember/destroyable';
+import { cleanGlobalRef } from '../utils/ref';
+
+export function initialize(appInstance) {
+  registerDestructor(appInstance, () => {
+    cleanGlobalRef();
+  });
+}
+
+export default {
+  initialize,
+};

--- a/addon/modifiers/create-ref.js
+++ b/addon/modifiers/create-ref.js
@@ -4,7 +4,6 @@ import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import {
-  maybeCleanGlobalRef,
   setGlobalRef,
   bucketFor,
   getNodeDestructors,
@@ -23,7 +22,6 @@ export default class RefModifier extends Modifier {
     setGlobalRef(getOwner(this));
 
     registerDestructor(this, () => {
-      maybeCleanGlobalRef(getOwner(this));
       this.cleanMutationObservers();
       this.cleanResizeObservers();
       getNodeDestructors(this._element).forEach((cb) => cb());

--- a/addon/modifiers/create-ref.js
+++ b/addon/modifiers/create-ref.js
@@ -4,6 +4,7 @@ import { getOwner } from '@ember/application';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import {
+  maybeCleanGlobalRef,
   setGlobalRef,
   bucketFor,
   getNodeDestructors,
@@ -22,6 +23,7 @@ export default class RefModifier extends Modifier {
     setGlobalRef(getOwner(this));
 
     registerDestructor(this, () => {
+      maybeCleanGlobalRef(getOwner(this));
       this.cleanMutationObservers();
       this.cleanResizeObservers();
       getNodeDestructors(this._element).forEach((cb) => cb());

--- a/addon/utils/ref.js
+++ b/addon/utils/ref.js
@@ -17,12 +17,6 @@ export function setGlobalRef(value) {
   lastGlobalRef = value;
 }
 
-export function maybeCleanGlobalRef(value) {
-  if (lastGlobalRef === value) {
-    cleanGlobalRef();
-  }
-}
-
 export function cleanGlobalRef() {
   lastGlobalRef = null;
 }

--- a/addon/utils/ref.js
+++ b/addon/utils/ref.js
@@ -17,6 +17,16 @@ export function setGlobalRef(value) {
   lastGlobalRef = value;
 }
 
+export function maybeCleanGlobalRef(value) {
+  if (lastGlobalRef === value) {
+    cleanGlobalRef();
+  }
+}
+
+export function cleanGlobalRef() {
+  lastGlobalRef = null;
+}
+
 export function resolveGlobalRef() {
   return lastGlobalRef;
 }

--- a/app/instance-initializers/global-ref-cleanup.js
+++ b/app/instance-initializers/global-ref-cleanup.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  initialize,
+} from 'ember-ref-bucket/instance-initializers/global-ref-cleanup';


### PR DESCRIPTION
It fixes a memory leak where `lastGlobalRef` keep an application around in tests:

![image](https://github.com/lifeart/ember-ref-bucket/assets/4335166/d66f52bf-4897-4a04-b84c-2d11add4ddb1)

Closes: https://github.com/lifeart/ember-ref-bucket/issues/50

# 🙋‍♂️ For reviewers' consideration

As mentioned by @lifeart

> We could try do few things:

> - register destructor inside modifier, but binded to app instance (getOwner(this)).
> - implement app-initializer flow to register / remove globalRef

We indeed can do two things. I feel like cleaning up after modifier is destroyed is a better idea. `app-initializer` can do it as well but that would be a solution to satisfy the tests.

I think that currently, in the normal usage of an application `lastGlobalRef` is kept longer than needed. I think the referenced object is only released when a new `{{create-ref}}` overrides it. So we often have a bit more in memory than necessary. That's why I took the route of the modifier cleaning up after itself.

## Help needed

I'm not sure how to write a test for that. I was thinking about checking if `lastGlobalRef` is cleaned up after changing `isToggled`:

```js
test('it cleans up `lastGlobalRef` after itself ', async function (assert) {
  this.set('isToggled', true);
  await render(
    hbs`{{#if this.isToggled}}<div {{create-ref "foo"}}>octane</div>`
  );
  
  // Somehow assert that `lastGlobalRef` is set

  this.set('isToggled', false);

  // Somehow assert that `lastGlobalRef` is no longer set
});
```

but how can I access `lastGlobalRef` in tests?