### PR TITLE
fix: typo character option and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ const domNode = nodeFor(this, 'field');
 Options:
 * `resize` - default: `false`, if truthy observes the resizing of the DOM element.
 * `attributes` - default: `false`, if truthy observes the changing of any attribute on the DOM element.
-* `characterdata` - default: `false`, if truthy observes the change of the innerText of the DOM element. Note that setting innerText can change the childlist or the characterdata depending on the current content of the element.
-* `childlist` - default: `false`, if truthy observes changes to the list of direct children of the DOM element.
+* `character` - default: `false`, if truthy observes the change of the innerText of the DOM element. Note that setting innerText can change the children or the character depending on the current content of the element.
+* `children` - default: `false`, if truthy observes changes to the list of direct children of the DOM element.
 * `subtree` - default: `false`, if truthy observes the above options on the entire DOM subtree, not just the element decorated by the modifier.
 
 

--- a/addon/modifiers/create-ref.js
+++ b/addon/modifiers/create-ref.js
@@ -54,7 +54,12 @@ export default class RefModifier extends Modifier {
     this._mutationsObserver = new MutationObserver(this.markDirty);
     const opts = this.getObserverOptions(named);
     delete opts.resize;
-    if (opts.attributes || opts.characterdata || opts.childlist) {
+    if (
+      opts.attributes ||
+      opts.characterData ||
+      opts.childlist ||
+      opts.subtree
+    ) {
       // mutations observer throws if observe is attempted
       // with all these options disabled
       this._mutationsObserver.observe(this._element, opts);

--- a/tests/integration/modifiers/create-ref-test.js
+++ b/tests/integration/modifiers/create-ref-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, find, waitUntil } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { ref, globalRef, nodeFor } from 'ember-ref-bucket';
 
@@ -37,11 +37,18 @@ module('Integration | Modifier | create-ref', function (hooks) {
     assert.equal(nodeFor(this, 'foo').textContent, 'octane');
   });
 
-  test('it has proper transform for {{create-tracked-ref resize=true attributes=true}} case', async function (assert) {
-    await render(
-      hbs`<div {{create-tracked-ref "foo" attributes=true}}>octane</div>`
-    );
+  test('it has proper transform for {{create-tracked-ref character=true subtree=true}} case', async function (assert) {
+    assert.expect(3);
+    this.set('text', 'octane');
+    await render(hbs`
+      <div {{create-tracked-ref "foo" character=true subtree=true}}>{{this.text}}</div>
+      <div data-test-mirror>{{get (tracked-ref-to "foo") 'textContent'}}</div>
+    `);
     assert.equal(nodeFor(this, 'foo').textContent, 'octane');
+    assert.equal(find('[data-test-mirror]').textContent, 'octane');
+    this.set('text', 'polaris');
+    waitUntil(() => find('[data-test-mirror]').textContent === 'polaris');
+    assert.ok(true);
   });
 
   test('it has proper transform for {{create-global-ref}} case', async function (assert) {


### PR DESCRIPTION
# Tasks:
 * Fix observing `characterData` when pass `character=true` as option for `{{create-tracked-ref}}`
 * Update `Options` docs section to correct param names