### PR TITLE
Add tests for memory leak prevention coming from lastGlobalRef

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -7,6 +7,8 @@ export function nodeFor(context, name) {
   return bucketFor(context).get(name);
 }
 
+export { resolveGlobalRef };
+
 function maybeReturnCreated(value, createdValues, fn, ctx) {
   if (value === null || value === undefined) {
     return null;


### PR DESCRIPTION
@lifeart I think you merged [my change](https://github.com/lifeart/ember-ref-bucket/pull/51) too early. I was still working on tests 😉 (I should have turned it into draft mode)