### PR TITLE
[BUG] Fix compatibility issue when WeakRef is not supported

### DIFF
--- a/addon/utils/ref.js
+++ b/addon/utils/ref.js
@@ -32,17 +32,19 @@ function fromWeakRefIfSupported(node) {
 
 /**
  *
- * @param {null | undefined | WeeakRef | HTMLElement } node
+ * @param {null | undefined | WeakRef | HTMLElement } node
  * @returns
  */
 function toWeakRefIfSupported(node) {
   if (node === null || node === undefined) {
     return null;
   }
-  if (node instanceof WeakRef) {
-    return node;
-  }
-  if (hasWeakRef) {
+  if(hasWeakRef)
+  {
+    if (node instanceof WeakRef) {
+      return node;
+    }
+
     return new WeakRef(node);
   }
   return node;


### PR DESCRIPTION
`ember-ref-bucket` generates an exception on browsers that don't support WeakRef.

Tests were not passing on Safari 13

![Screenshot 2023-12-11 at 8 07 52 AM](https://github.com/lifeart/ember-ref-bucket/assets/743977/04bd114b-75c9-40cb-ad7a-ffbb1b4550fd)
