### PR TITLE
Add assertion to verify preprocessor was run on create-ref modifier

### DIFF
--- a/addon/modifiers/create-ref.js
+++ b/addon/modifiers/create-ref.js
@@ -2,7 +2,7 @@ import Modifier from 'ember-modifier';
 import { getOwner } from '@ember/application';
 
 import { action } from '@ember/object';
-import { assert } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 import {
   setGlobalRef,
   bucketFor,
@@ -127,6 +127,11 @@ export default class RefModifier extends Modifier {
     this._ctx = ctx;
     this._element = element;
 
+    warn(
+      `Preprocessor was not executed on create-ref modifier. If the reference is not set, check that ember-ref-bucket is included in the dependencies (not devDependencies) in package.json.`,
+      typeof named.debugName === 'string' || !!named.bucket,
+      { id: 'ember-ref-bucket.no-preprocessor' }
+    );
     assert(
       `You must provide string as first positional argument for {{${named.debugName}}}`,
       typeof name === 'string' && name.length > 0


### PR DESCRIPTION
Our team uses `ember-ref-bucket` in one of our private addons and an app that uses that addon. We did not have `ember-ref-bucket` in the dependencies for the app, which caused an issue where we could use `create-ref` but the bucket was set incorrectly because the preprocessor was not running on the app code.

This took us a while to debug. The assertion in this PR would provide immediate feedback in development/test and the action to take to resolve. I'm happy to change this if you have any feedback.

Thanks for your work on this addon!