### PR TITLE
Remove deprecation warnings logged in newer versions of `@glimmer/syntax`

### DIFF
--- a/lib/ref-transform.js
+++ b/lib/ref-transform.js
@@ -15,7 +15,8 @@
 
 /**
  * This function is used to get the original value of the node path
- * respecting the `@glimmer/syntax` deprecations
+ * respecting the `@glimmer/syntax` deprecations introduced here
+ * (https://github.com/glimmerjs/glimmer-vm/pull/1568)
  *
  * @param {AST.Statement} node `@glimmer` AST statement node
  * @returns {string} node path original value

--- a/lib/ref-transform.js
+++ b/lib/ref-transform.js
@@ -13,23 +13,42 @@
   ```
 */
 
+/**
+ * This function is used to get the original value of the node path
+ * respecting the `@glimmer/syntax` deprecations
+ *
+ * @param {AST.Statement} node `@glimmer` AST statement node
+ * @returns {string} node path original value
+ */
+function getNodeOriginalValue(node) {
+  if (!node || !node.path) {
+    return null;
+  } else if (Object.hasOwnProperty.call(node.path, 'value')) {
+    return node.path.value;
+  } else {
+    return node.path.original;
+  }
+}
+
 function refTransform({ syntax }) {
   let b = syntax.builders;
 
+  const localNames = ['create-ref', 'ref-to'];
+  const globalNames = ['create-global-ref', 'global-ref-to'];
+  const trackedNames = [
+    'create-tracked-ref',
+    'create-tracked-global-ref',
+    'tracked-ref-to',
+    'tracked-global-ref-to',
+  ];
+  const typos = {
+    'create-global-tracked-ref': 'create-tracked-global-ref',
+    'global-tracked-ref-to': 'tracked-global-ref-to',
+  };
+
   function transformNode(node) {
-    const localNames = ['create-ref', 'ref-to'];
-    const globalNames = ['create-global-ref', 'global-ref-to'];
-    const trackedNames = [
-      'create-tracked-ref',
-      'create-tracked-global-ref',
-      'tracked-ref-to',
-      'tracked-global-ref-to',
-    ];
-    const typos = {
-      'create-global-tracked-ref': 'create-tracked-global-ref',
-      'global-tracked-ref-to': 'tracked-global-ref-to',
-    };
-    const originalName = node.path.original;
+    const originalName = getNodeOriginalValue(node);
+
     if (Object.keys(typos).includes(originalName)) {
       throw new Error(`
           "ember-ref-bucket", looks like you have typo in modifier or helper name:
@@ -52,14 +71,14 @@ function refTransform({ syntax }) {
       node.hash.pairs.push(b.pair('debugName', b.string(originalName)));
     }
     if (trackedNames.includes(originalName)) {
-      node.path = b.path(node.path.original.replace('tracked-', ''));
+      node.path = b.path(getNodeOriginalValue(node).replace('tracked-', ''));
       node.hash.pairs = node.hash.pairs.filter(({ key }) => key !== 'tracked');
       node.hash.pairs.push(b.pair('tracked', b.boolean(true)));
     }
-    if (globalNames.includes(node.path.original)) {
+    if (globalNames.includes(getNodeOriginalValue(node))) {
       node.hash.pairs = node.hash.pairs.filter(({ key }) => key !== 'bucket');
-      node.path = b.path(node.path.original.replace('global-', ''));
-    } else if (localNames.includes(node.path.original)) {
+      node.path = b.path(getNodeOriginalValue(node).replace('global-', ''));
+    } else if (localNames.includes(getNodeOriginalValue(node))) {
       if (node.params.length === 2) {
         throw new Error('ember-ref-bucket does not support ember-ref-modifier');
       }


### PR DESCRIPTION
### Get the node path `value` instead of `original` when available

This PR aims to remove the deprecations warnings triggered by newer versions of the @glimmer/syntax library. 

In our application, building the project logs thousands of warning like below:
```
DEPRECATION: The original property on literal nodes is deprecated, use value instead
DEPRECATION: The original property on literal nodes is deprecated, use value instead
DEPRECATION: The original property on literal nodes is deprecated, use value instead
...
```

You can view the changes introduced in `glimmer/syntax` here https://github.com/glimmerjs/glimmer-vm/pull/1568.


