### PR TITLE
TypeError when using subtree=true without other mutation observer options

### DIFF
--- a/addon/modifiers/create-ref.js
+++ b/addon/modifiers/create-ref.js
@@ -59,12 +59,7 @@ export default class RefModifier extends Modifier {
     this._mutationsObserver = new MutationObserver(this.markDirty);
     const opts = this.getObserverOptions(named);
     delete opts.resize;
-    if (
-      opts.attributes ||
-      opts.characterData ||
-      opts.childList ||
-      opts.subtree
-    ) {
+    if (opts.attributes || opts.characterData || opts.childList) {
       // mutations observer throws if observe is attempted
       // with all these options disabled
       this._mutationsObserver.observe(this._element, opts);

--- a/tests/integration/modifiers/create-ref-test.js
+++ b/tests/integration/modifiers/create-ref-test.js
@@ -45,6 +45,13 @@ module('Integration | Modifier | create-ref', function (hooks) {
     assert.equal(nodeFor(this, 'foo').textContent, 'octane');
   });
 
+  test('it does not throw when subtree=true is used without other mutation observer options', async function (assert) {
+    await render(
+      hbs`<div {{create-tracked-ref "foo" subtree=true}}>hello</div>`
+    );
+    assert.equal(nodeFor(this, 'foo').textContent, 'hello');
+  });
+
   test('it has proper transform for {{create-tracked-ref character=true subtree=true}} case', async function (assert) {
     assert.expect(3);
     this.set('text', 'octane');


### PR DESCRIPTION
Closes: https://github.com/lifeart/ember-ref-bucket/issues/81

Dummy app throws an error:

<img width="3824" height="2240" alt="image" src="https://github.com/user-attachments/assets/b577f22a-3bb4-4d89-bb6c-860752f3b30f" />

```
create-ref.js:62 

Uncaught TypeError: Failed to execute 'observe' on 'MutationObserver': The options object must set at least one of 'attributes', 'characterData', or 'childList' to true.
    at RefModifier.installMutationObservers (create-ref.js:62:1)
    at RefModifier.modify (create-ref.js:134:1)
    at ClassBasedModifierManager.installModifier (index.js:20:491)
    at CustomModifierManager.install (manager.js:637:1)
    at runtime.js:4048:1
    at track (validator.js:668:1)
    at TransactionImpl.commit (runtime.js:4046:1)
    at EnvironmentImpl.commit (runtime.js:4121:1)
    at inTransaction (runtime.js:4141:1)
    at Renderer._renderRoots (index.js:6996:1)
```

In `installMutationObservers`, the guard that decides whether to call `observe()` included `opts.subtree` as a sufficient condition:

```js
if (opts.attributes || opts.characterData || opts.childList || opts.subtree) {
  this._mutationsObserver.observe(this._element, opts);
}
```                                                                                                                                                                                                                       
                                         
However, `subtree` is not an observation type - it's a scope modifier that tells the other observers to also watch descendant nodes. The browser's `MutationObserver.observe()` API requires [at least one of attributes, characterData, or childList to be true](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe#options), and rejects subtree-only configs.

As a fix, I'm removing `opts.subtree` from the condition.

----

The fix was done in TDD style. The extra test I added fails without the fix:

<img width="2170" height="1036" alt="image" src="https://github.com/user-attachments/assets/c5be8d1a-7599-407b-8539-ecaf40dcc390" />
